### PR TITLE
Fix inact_odr_t enum variants

### DIFF
--- a/iis2dulpx_reg.h
+++ b/iis2dulpx_reg.h
@@ -2639,10 +2639,10 @@ typedef enum
 
 typedef enum
 {
-  IIS2DULPX_ODR_NO_CHANGE       = 0,  /* no odr change during inactivity state */
-  IIS2DULPX_ODR_1_6_HZ          = 1,  /* set odr to 1.6Hz during inactivity state */
-  IIS2DULPX_ODR_3_HZ            = 1,  /* set odr to 3Hz during inactivity state */
-  IIS2DULPX_ODR_25_HZ           = 1,  /* set odr to 25Hz during inactivity state */
+  IIS2DULPX_ODR_NO_CHANGE       = 0x0,  /* no odr change during inactivity state */
+  IIS2DULPX_ODR_1_6_HZ          = 0x1,  /* set odr to 1.6Hz during inactivity state */
+  IIS2DULPX_ODR_3_HZ            = 0x2,  /* set odr to 3Hz during inactivity state */
+  IIS2DULPX_ODR_25_HZ           = 0x3,  /* set odr to 25Hz during inactivity state */
 } iis2dulpx_inact_odr_t;
 
 typedef struct


### PR DESCRIPTION
#### Summary
This PR addresses an issue in the `iis2dulpx_inact_odr_t` enum where all the variants, except for the first one, were incorrectly set to `1`. The values have been corrected based on the register description documentation under **section 8.8**.

#### Changes
Updated the `iis2dulpx_inact_odr_t` enum to align with the correct values as specified in the documentation.