### PR TITLE
Removed useless reg write in emb_fsm_en_get

### DIFF
--- a/iis2dulpx_reg.c
+++ b/iis2dulpx_reg.c
@@ -3397,9 +3397,6 @@ int32_t iis2dulpx_emb_fsm_en_get(const stmdev_ctx_t *ctx, uint8_t *val)
                              (uint8_t *)&emb_func_en_b, 1);
 
     *val = emb_func_en_b.fsm_en;
-
-    ret += iis2dulpx_write_reg(ctx, IIS2DULPX_EMB_FUNC_EN_B,
-                               (uint8_t *)&emb_func_en_b, 1);
   }
 
   ret += iis2dulpx_mem_bank_set(ctx, IIS2DULPX_MAIN_MEM_BANK);


### PR DESCRIPTION
#### Summary
This PR removes a redundant register write in the `iis2dulpx_emb_fsm_en_get` function. The write operation was unnecessary and did not contribute to the functionality of the code.

#### Changes
Eliminated the redundant register write in `iis2dulpx_emb_fsm_en_get`.